### PR TITLE
Give better context of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 roadmap
 =======
 
-Gathering feedback from the community to inform roadmap.
+This repository's issue tracker is used to discuss the 
+[Node.js Roadmap](https://github.com/nodejs/node/blob/master/ROADMAP.md).
+
+The code hosted here is for the legacy [io.js Roadmap](http://roadmap.iojs.org/) website and no further changes
+(Pull Requests) are needed.
+
 
 Contributors Welcome
 --------------------
 
- * [Current Roadmap](https://github.com/iojs/io.js/blob/v1.x/ROADMAP.md)
- * [Tracing Working Group](https://github.com/iojs/tracing-wg)
- * [Streams Working Group](https://github.com/iojs/readable-stream)
+Please use the issue tracker to share your ideas and participate on roadmap topics.
 
  ## People
 
- Current WG Members:
+Current WG Members:
 
 * Mikeal Rogers (@mikeal)
 * Bert Belder (@piscisaureus)


### PR DESCRIPTION
This repo is a bit confusing now that so many things have progressed!

I took a stab at updating the README. Tried to Keep It Simple.

Also, if someone could change the repo description-
![screenshot 2016-04-17 13 06 15](https://cloud.githubusercontent.com/assets/739813/14589877/d7b494ba-04a1-11e6-9818-95c850442fee.png)


Maybe just say "A place to discuss the Node.js roadmap"... but I definitely think the url should be removed.

